### PR TITLE
stopping autoplay of main page carousel

### DIFF
--- a/_includes/js/site-setup.js
+++ b/_includes/js/site-setup.js
@@ -39,7 +39,7 @@
       slideshow.slickPlay();
     });
   }).slick({
-    autoplay: true,
+    autoplay: false,
     pauseOnHover: false
   })
 


### PR DESCRIPTION
Main carousel on home page was moving too fast.  Bad UX.  Fixed.