### PR TITLE
Fix blog author links to team pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,8 @@ exclude:
   - Procfile
   - Rakefile
   - node_modules
+include:
+  - _redirects
 collections:
   team_and_board:
     output: true

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,7 @@
+/team/emily-jacobi /team/emily
+/team/aliya-ryan /team/aliya
+/team/gregor-maclennan /team/gregor
+/team/james-halliday /team/substack
+/team/stephen-whitmore /team/noffle
+/team/jen-castro /team/jen
+/team/aldo-puicon /team/aldo


### PR DESCRIPTION
Currently the links from the author on the blog page go to 404 not found.