### PR TITLE
feat: Update donate form & add text for Covid fund

### DIFF
--- a/donate/index.html
+++ b/donate/index.html
@@ -4,18 +4,21 @@ published: true
 ---
 <div class="row">
   <div class="small-12 large-6 columns">
-    <h2>Support our work</h2>
-    <p>All donations help us partner with communities worldwide to build and use technology to defend their rights. <strong>Please make your tax-deductible contribution today.</strong></p>
+    <h2>Support our partners in Peru</h2>
+    <p>Currently all donations will go to support our Covid Emergency Fund to support indigenous partners in the Peruvian Amazon. <strong>Please make your tax-deductible contribution today.</strong></p>
     <hr>
   </div>
   <div class="small-12 large-6 columns">
     <div class="donate-form-wrapper">
       <script
-        src="https://www.dntly.com/assets/js/v1/form.js"
-        data-donately-id="act_16d7a3b1160b"
-        data-stripe-publishable-key="pk_live_LLK3uNLcpQzfXoNg9FZ1WnuI"
-        data-donately-amount="25"
-        data-donately-presets="50,100,250,500,1000">
+        src="https://cdn.donately.com/dntly-core/3.6/core.min.js"
+        data-donately-id='act_16d7a3b1160b'
+        data-stripe-publishable-key='pk_live_LLK3uNLcpQzfXoNg9FZ1WnuI'
+        data-donately-form-id='frm_19c3fbfad38b'
+        data-donately-presets='50,100,250,500,1000'
+        data-donately-amount='25'
+        data-donately-payment-options='cc,ach,paypal'
+        data-donately-donor-pays-fees='{"cc":{"processor_percent":0.029,"processor_fixed":0.3,"processor_cap":"","dntly_percent":0.03,"complex_calc":true},"ach":{"processor_percent":0.008,"processor_fixed":0,"processor_cap":5,"dntly_percent":0.03,"complex_calc":true},"paypal":{"processor_percent":0.029,"processor_fixed":0.3,"processor_cap":"","dntly_percent":0.03,"complex_calc":true}}' data-donately-campaign-id='cmp_4ccb03e03bae'>
       </script>
     </div>
     <script type="text/javascript">

--- a/donate/index.html
+++ b/donate/index.html
@@ -4,12 +4,12 @@ published: true
 ---
 <div class="row">
   <div class="small-12 large-6 columns">
-    <h3>Support our work</h2>
+    <h2>Support our work</h2>
     <p>
       All donations help us partner with communities worldwide to build and use technology to defend their rights.
       <strong>Please make your tax-deductible contribution today.</strong>
     </p>
-    <h3>May 2020: Support Frontline Communities fighting the Coronavirus Pandemic</h3>
+    <h4>May 2020: Support Frontline Communities fighting the Coronavirus Pandemic</h4>
     <p>
       To contribute directly to our grassroots Indigenous partners,
       please <a href="/covid" target="_blank" rel=”noopener noreferrer”>donate directly to our Covid Emergency fund.</a>
@@ -17,7 +17,7 @@ published: true
       immediate food & sanitation needs during the pandemic.
     </p>
     <p>
-      <strong><a href="/covid" target="_blank" rel=”noopener noreferrer”>Support Frontline Communities</a></strong>
+      <strong><a href="/covid" target="_blank" rel=”noopener noreferrer”>Donate to the Covid Emergency Fund</a></strong>
     </p>
     <hr>
   </div>

--- a/donate/index.html
+++ b/donate/index.html
@@ -4,8 +4,21 @@ published: true
 ---
 <div class="row">
   <div class="small-12 large-6 columns">
-    <h2>Support our partners in Peru</h2>
-    <p>Currently all donations will go to support our Covid Emergency Fund to support indigenous partners in the Peruvian Amazon. <strong>Please make your tax-deductible contribution today.</strong></p>
+    <h3>Support our work</h2>
+    <p>
+      All donations help us partner with communities worldwide to build and use technology to defend their rights.
+      <strong>Please make your tax-deductible contribution today.</strong>
+    </p>
+    <h3>May 2020: Support Frontline Communities fighting the Coronavirus Pandemic</h3>
+    <p>
+      To contribute directly to our grassroots Indigenous partners,
+      please <a href="/covid" target="_blank" rel=”noopener noreferrer”>donate directly to our Covid Emergency fund.</a>
+      100% of your donation to Indigenous partners in Peru working to meet
+      immediate food & sanitation needs during the pandemic.
+    </p>
+    <p>
+      <strong><a href="/covid" target="_blank" rel=”noopener noreferrer”>Support Frontline Communities</a></strong>
+    </p>
     <hr>
   </div>
   <div class="small-12 large-6 columns">


### PR DESCRIPTION
This changes the text on our donate page to explain that donations are currently for the Covid Emergency Fund.

It also updates the form that we are using from Donately to add options to donate via paypal and ACH (lower fees). In addition the donately form is now tagged to go to the Covid Emergency fund campaign that I have now created in Donately.

We could optionally add a dropdown field to the form allowing the donor to choose whether this is for the Covid Fund or for Digital Democracy. I can make this change if it makes sense.