### PR TITLE
fix: Fix layout on small screens

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@ layout: no_nav
       <li><a href="https://www.earthdefenderstoolkit.com">Earth Defenders Toolkit</a></li>
       <li><a href="/ourwork/">Our Work</a></li>
       <li><a href="/blog/">Blog</a></li>
-      <li><a href="/aboutus/">About Us</a></li>
+      <li><a href="/aboutus/">About</a></li>
       <li>
         <a class="donate" href="/donate/">Donate</a>
       </li>

--- a/_sass/components/_topbar.scss
+++ b/_sass/components/_topbar.scss
@@ -127,9 +127,9 @@ header.site-header {
     min-height: calc(100vh - 85px);
     background-color: $dd-blue-dark;
     display: flex;
-    justify-content: space-around;
+    justify-content: space-evenly;
     flex-direction: column;
-    padding: 45px 0 78px 0;
+    // padding: 45px 0 78px 0;
     opacity: 1;
   }
 

--- a/_sass/components/_topbar.scss
+++ b/_sass/components/_topbar.scss
@@ -175,13 +175,14 @@ header.site-header {
         display: none;
       }
       & > a {
-        white-space: nowrap;
+        // white-space: nowrap;
         display: block;
         width: 100%;
         font-weight: $topbar-link-weight;
         padding: 5px 24px;
         color: white;
         font-size: 2.2rem;
+        line-height: 1.3;
 
         // &.donate {
           // font-size: 2.3rem;
@@ -253,6 +254,7 @@ header.site-header {
     }
 
     ul {
+      white-space: nowrap;
       width: auto;
       margin: 0;
       background-color: transparent;

--- a/_sass/components/_topbar.scss
+++ b/_sass/components/_topbar.scss
@@ -183,26 +183,26 @@ header.site-header {
         color: white;
         font-size: 2.2rem;
 
-        &.donate {
-          font-size: 2.3rem;
-          padding: 32px 24px;
-          position: relative;
-          margin: 16px 0px;
-          &:before, &:after {
-            content: "";
-            position: absolute;
-            height: 1px;
-            background-color: rgba(255,255,255,0.5);
-            width: 40px;
-            left: 24px;
-          }
-          &:before {
-            top: 0;
-          }
-          &:after {
-            bottom: 0;
-          }
-        }
+        // &.donate {
+          // font-size: 2.3rem;
+          // padding: 32px 24px;
+          // position: relative;
+          // margin: 16px 0px;
+          // &:before, &:after {
+          //   content: "";
+          //   position: absolute;
+          //   height: 1px;
+          //   background-color: rgba(255,255,255,0.5);
+          //   width: 40px;
+          //   left: 24px;
+          // }
+          // &:before {
+          //   top: 0;
+          // }
+          // &:after {
+          //   bottom: 0;
+          // }
+        // }
         &.lang {
           text-transform: uppercase;
           font-weight: 300;
@@ -287,8 +287,8 @@ header.site-header {
             }
           }
           &.donate {
-            padding: 5px 17px;
-            margin: 0 28px 0 14px;
+            // padding: 5px 17px;
+            // margin: 0 28px 0 14px;
             font-size: 1.2em;
             color: white;
             background-color: #FF3301;

--- a/_sass/pages/_front-page.scss
+++ b/_sass/pages/_front-page.scss
@@ -4,7 +4,7 @@
 
 $medium-down: "#{$screen} and (max-width:#{upper-bound($medium-range)})" !default;
 
-#content { 
+#content {
   @media #{$medium-down} {
     padding: 80px 0px;
   }
@@ -27,6 +27,7 @@ $medium-down: "#{$screen} and (max-width:#{upper-bound($medium-range)})" !defaul
     font-size: 1.2rem;
     margin: -1.7em 0 0 0;
     position: relative;
+    overflow: hidden;
     i, em {
       color: rgba(255,255,255,0.75);
       background-color: $dd-blue-dark;


### PR DESCRIPTION
Adding the "Earth Defenders Toolkit" menu item affected layout on small screens. This makes the following fixes:

- Change "About Us" to "About" to reduce space in nav bar
- Remove extra padding around "Donate" button
- On small mobile screens, wrap the text for nav menu items
- Space the nav menu items evenly on mobile screens
- Fix overflow issue on small mobile screens (iPhone 5)

![ipad landscape](https://user-images.githubusercontent.com/290457/123784270-2aa1aa80-d8cf-11eb-9e55-1a9b162adce3.png)
![iPhone 5](https://user-images.githubusercontent.com/290457/123784300-31c8b880-d8cf-11eb-8f24-85a7af47f3cc.png)
![moto G4](https://user-images.githubusercontent.com/290457/123784301-31c8b880-d8cf-11eb-9c48-9c886b771b2f.png)
