### PR TITLE
Fix: Update links for mapeo desktop download

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -16,7 +16,7 @@
 /* /es/:splat 302 Language=es
 /mapeo/icca/android https://mapeo-apks.ddem.us/icca/latest 302
 /mapeo/latest/android https://mapeo-apks.ddem.us/latest 302
-/mapeo/latest/mac https://github.com/digidem/mapeo-desktop/releases/download/v5.3.1/Installar_Mapeo_v5.3.1_mac.dmg 302
-/mapeo/latest/windows https://github.com/digidem/mapeo-desktop/releases/download/v5.3.1/Installar_Mapeo_v5.3.1_win-x64.exe 302
-/mapeo/latest/win32 https://github.com/digidem/mapeo-desktop/releases/download/v5.3.1/Installar_Mapeo_v5.3.1_win-ia32.exe 302
-/mapeo/latest/linux https://github.com/digidem/mapeo-desktop/releases/download/v5.3.1/Installar_Mapeo_v5.3.1_linux.deb 302
+/mapeo/latest/mac https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_mac.dmg 302
+/mapeo/latest/windows https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_win-x64.exe 302
+/mapeo/latest/win32 https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_win-ia32.exe 302
+/mapeo/latest/linux https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_linux.deb 302


### PR DESCRIPTION
Updates the link in the redirect file for mapeo downloads.

Downloads for Mapeo Desktop should point to the latest release.