### PR TITLE
fix: Update download links for Mapeo Desktop

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -16,7 +16,7 @@
 /* /es/:splat 302 Language=es
 /mapeo/icca/android https://mapeo-apks.ddem.us/icca/latest 302
 /mapeo/latest/android https://mapeo-apks.ddem.us/latest 302
-/mapeo/latest/mac https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_mac.dmg 302
-/mapeo/latest/windows https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_win-x64.exe 302
-/mapeo/latest/win32 https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_win-ia32.exe 302
-/mapeo/latest/linux https://github.com/digidem/mapeo-desktop/releases/download/v5.4.0/Installar_Mapeo_v5.4.0_linux.deb 302
+/mapeo/latest/mac https://releases.mapeo.app/desktop/latest-mac 302
+/mapeo/latest/windows https://releases.mapeo.app/desktop/latest-win 302
+/mapeo/latest/win32 https://releases.mapeo.app/desktop/ia32/latest-win 302
+/mapeo/latest/linux https://releases.mapeo.app/desktop/latest-linux 302

--- a/mapeo/download.html
+++ b/mapeo/download.html
@@ -151,24 +151,28 @@ layout: default
 
 <script type="text/javascript">
   var os = window.platform.os;
-  var slug = os.family.toLowerCase();
+  var downloadLink = 'https://releases.mapeo.app/desktop/'
 
   // window.platform.os.family can sometimes be Ubuntu, CentOS, etc.. this
   // makes them all just 'linux'
-  if (/Linux/i.test(navigator.platform)) slug = 'linux';
-
-  // Use win32 for mapeo/latest/:slug: 
-  if (/Win/i.test(os.family) && os.architecture === 32) slug = 'win32';
-
-  // Use MAC for OSX 
-  if (/os x/i.test(slug)) slug = 'mac';
+  if (/Linux/i.test(navigator.platform)) {
+    // TODO: On Android this is what will likely download
+    downloadLink += 'latest-linux'
+  } else if (/os x/i.test(os.family.toLowerCase())) {
+    downloadLink += 'latest-mac'
+  } else if (/Win/i.test(os.family)) {
+    if (os.architecture === 32) {
+      downloadLink += 'ia32/latest-win'
+    } else {
+      downloadLink += 'latest-win'
+    }
+  }
 
   var el = document.getElementById('download-link');
   var frame = document.getElementById('download-frame');
-  el.href = '/mapeo/latest/' + slug;
-  frame.src = '/mapeo/latest/' + slug;
+  el.href = frame.src = downloadLink
 
-  if (/mac/.test(slug)) {
+  if (/os x/i.test(os.family.toLowerCase())) {
     var section = document.createElement('section');
     section.className = 'instructions bg-white';
     var img = document.createElement('img');


### PR DESCRIPTION
We now have fixed URLs for Mapeo Desktop downloads via [mapeo-releases-worker](https://github.com/digidem/mapeo-releases-worker). This updates the download links on the website to use those.