### PR TITLE
move redirect rules for spanish to end

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -10,13 +10,13 @@
 /covid https://pages.donately.com/digidem/campaign/peruvian-amazon-covid-emergency-fund
 # Redirect blog posts to WP domain
 /blog/* https://wp.digital-democracy.org/:splat 302!
-# Show english pages for missing spanish pages
-/es/* /:splat 200
-# Redirect Spanish language users to Spanish version of the site
-/* /es/:splat 302 Language=es
 /mapeo/icca/android https://mapeo-apks.ddem.us/icca/latest 302
 /mapeo/latest/android https://mapeo-apks.ddem.us/latest 302
 /mapeo/latest/mac https://releases.mapeo.app/desktop/latest-mac 302
 /mapeo/latest/windows https://releases.mapeo.app/desktop/latest-win 302
 /mapeo/latest/win32 https://releases.mapeo.app/desktop/ia32/latest-win 302
 /mapeo/latest/linux https://releases.mapeo.app/desktop/latest-linux 302
+# Show english pages for missing spanish pages
+/es/* /:splat 200
+# Redirect Spanish language users to Spanish version of the site
+/* /es/:splat 302 Language=es


### PR DESCRIPTION
fixes #215 

things to check:
- non-download links that used to redirect due to Spanish locale detection still do so
- download links in /mapeo/downloads/ actually work