### PR TITLE
feat: Embed job postings from Workable

### DIFF
--- a/_aboutus/jobs.html
+++ b/_aboutus/jobs.html
@@ -9,24 +9,14 @@ featured: small
 
 {% assign jobs_available = false %}
 <section class="row grid">
-<div class="columns">
   <h2>Job Opportunities</h2>
-  <ul class="large-block-grid-2 small-block-grid-1">
-    {% for post in site.jobs %}
-    {% unless post.published == false %}
-    {% assign jobs_available = true %}
-    <li>
-      <h4><b><a href="{{ post.url }}">{{ post.title }}</a></b></h4>
-      <p class="subhead">{{ post.excerpt }}</p>
-      <p><a href="{{ post.url }}">Learn more & apply</a></p>
-    </li>
-    {% endunless %}
-    {% endfor %}
-  </ul>
-  {% unless jobs_available %}
-  <p>We have no open job opportunities at this time.</p>
-  {% endunless %}
-</div>
+  <script src='https://www.workable.com/assets/embed.js' type='text/javascript'></script>
+  <script type='text/javascript' charset='utf-8'>
+  whr(document).ready(function(){
+  whr_embed(526960, {detail: 'descriptions', base: 'jobs', zoom: 'country', grouping: 'none'});
+  });
+  </script>
+  <div id="whr_embed_hook"></div>
 </section>
 
 {% assign internships_available = false %}

--- a/_sass/pages/_aboutus-page.scss
+++ b/_sass/pages/_aboutus-page.scss
@@ -28,3 +28,18 @@
     }
   }
 }
+
+/** Job postings embed from workable */
+
+.whr-info {
+  /** Hide location and date posted */
+  display: none;
+}
+.whr-description > *:not(:first-child) {
+  /** Only show first paragraph of job description in jobs list */
+  display: none;
+}
+.whr-description strong {
+  /** No bold text in job descriptions */
+  font-weight: normal;
+}


### PR DESCRIPTION
Workable have embed code for automatically listing the jobs available on Workable on our website. This removes the need for us to keep the website updated with the latest jobs, but _only_ if we use Workable.

The challenge with this is if we also want to post jobs to our website without Workable. Both Workable and our original website code had a "no jobs available at this time" that showed if there were no jobs published, so if we have both (original code and Workable) then one or both might say "no jobs available". Ideas on how to manage this? We can use CSS to hide the message from Workable, but then how to select whether to show the message for website-only jobs?